### PR TITLE
remove username from profile editing

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/vue/profile-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/vue/profile-page/index.vue
@@ -7,18 +7,6 @@
     <form @submit.prevent="submitEdits">
 
       <core-textbox
-        v-if="hasPrivilege('username')"
-        class="input-field"
-        :invalid="error"
-        :error="errorMessage"
-        :label="$tr('username')"
-        :value="session.username"
-        disabled
-        autocomplete="username"
-        id="username"
-        type="text" />
-
-      <core-textbox
         v-if="hasPrivilege('name')"
         class="input-field"
         :disabled="busy"
@@ -51,7 +39,6 @@
     $trs: {
       genericError: 'Something went wrong',
       success: 'Profile details updated!',
-      username: 'Username',
       name: 'Name',
       updateProfile: 'Update Profile',
     },
@@ -62,7 +49,6 @@
     },
     data() {
       return {
-        username: this.session.username,
         full_name: this.session.full_name,
       };
     },


### PR DESCRIPTION
re: https://trello.com/c/4wEaC64N/766-profile-page-username-is-shown-instead-of-phone-number-and-name-should-be-non-editable

Remove username entirely from profile page because it shows the salted version.

before:

![image](https://cloud.githubusercontent.com/assets/2367265/23818601/81a61d3e-05b1-11e7-8da6-c1a42819bf63.png)

after:

![image](https://cloud.githubusercontent.com/assets/2367265/23818606/9750213e-05b1-11e7-88d7-9c2e108c88ac.png)
