### PR TITLE
Fix path to README file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ dist_name = 'kolibri_instant_schools_plugin'
 plugin_name = 'kolibri_instant_schools_plugin'
 repo_url = 'https://github.com/fle-internal/kolibri-instant-schools-plugin'
 
-readme = read_file('README.rst')
+readme = read_file('README.md')
 doclink = """
 Documentation
 -------------


### PR DESCRIPTION
Got an error error `pip install -e .`. I believe it's because the README was converted to markdown.