### PR TITLE
Sign up page port

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -367,6 +367,7 @@
   .terms
     height: 80vh
     width: 80vw
+    border: none
     &-agreement
       $height-of-prompt = 18px + 16px
       $height-of-checkbox = 48px + 16px

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -76,20 +76,30 @@
 
       <!-- ToS modal only shows up if the box empty prior to clicking -->
       <!-- Using UI Checkbox for blur events and v-model -->
-      <k-checkbox
-        id="terms-agreement-checkbox"
-        :class="['terms-agreement-checkbox', termsNotAgreed ? 'invalid' : '']"
-        :checked="termsAgreed"
-        @change="showTerms = termsAgreed = $event"
-        @blur="termsAgreementCheckboxBlurred = true"
-        :label="$tr('termsAgreementLabel')"
-      />
-      <label
-        v-if="termsNotAgreed"
-        for="terms-agreement-checkbox"
-        class="terms-error-box"
-      >
-        {{ termsNotAgreedText }}
+      <label for="terms-agreement-checkbox">
+        <button
+          type="button"
+          class="terms-agreement-view-prompt"
+          @click="showTerms = true"
+        >
+          {{ $tr('viewTermsOfServicePrompt') }}
+        </button>
+
+        <k-checkbox
+          id="terms-agreement-checkbox"
+          :class="['terms-agreement-checkbox', termsNotAgreed ? 'invalid' : '']"
+          :checked="termsAgreed"
+          @change="termsAgreed = $event"
+          @blur="termsAgreementCheckboxBlurred = true"
+          :label="$tr('termsAgreementLabel')"
+        />
+
+        <span
+          v-if="termsNotAgreed"
+          class="terms-agreement-error-box"
+        >
+          {{ termsNotAgreedText }}
+        </span>
       </label>
 
       <k-button :disabled="busy" :primary="true" :text="$tr('finish')" type="submit" />
@@ -141,6 +151,7 @@
       logIn: 'Sign in',
       termsAgreementLabel: 'I agree to the terms of service & privacy policy',
       termsOfServiceModalHeader: 'Terms of service & privacy policy',
+      viewTermsOfServicePrompt: 'View terms of service & privacy policy',
       appBarHeader: 'Instant Schools',
       finish: 'Finish',
       required: 'This field is required',
@@ -356,14 +367,17 @@
   .terms
     height: 80vh
     width: 80vw
-    &-agreement-checkbox
-      text-decoration: underline
-      &.invalid
-        color: $keen-invalid-md-red
-    &-error-box
-      display: block
-      color: $keen-invalid-md-red // same color as input error messages
-      font-size: 14px // same as error messages from inputs
+    &-agreement
+      &-view-prompt
+        display: block
+        text-decoration: underline
+      &-checkbox
+        &.invalid
+          color: $keen-invalid-md-red
+      &-error-box
+        display: block
+        color: $keen-invalid-md-red // same color as input error messages
+        font-size: 14px // same as error messages from inputs
 
   .app-bar-icon
     font-size: 2.5em

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -76,11 +76,11 @@
 
       <!-- ToS modal only shows up if the box empty prior to clicking -->
       <!-- Using UI Checkbox for blur events and v-model -->
-      <ui-checkbox
+      <k-checkbox
         id="terms-agreement-checkbox"
         :class="['terms-agreement-checkbox', termsNotAgreed ? 'invalid' : '']"
-        v-model="termsAgreed"
-        @change="showTerms = termsAgreed"
+        :checked="termsAgreed"
+        @change="showTerms = termsAgreed = $event"
         @blur="termsAgreementCheckboxBlurred = true"
         :label="$tr('termsAgreementLabel')"
       />
@@ -118,13 +118,12 @@
   import { PageNames } from '../../constants';
   import { validateUsername } from 'kolibri.utils.validators';
   import kButton from 'kolibri.coreVue.components.kButton';
-  import uiCheckbox from 'keen-ui/src/UiCheckbox';
+  import kCheckbox from 'kolibri.coreVue.components.kCheckbox';
   import coreModal from 'kolibri.coreVue.components.coreModal';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import logo from 'kolibri.coreVue.components.logo';
   import uiIcon from 'keen-ui/src/UiIcon';
-  import uiSelect from 'keen-ui/src/UiSelect';
   import languageSwitcher from 'kolibri.coreVue.components.languageSwitcher';
 
   export default {
@@ -152,10 +151,9 @@
       uiToolbar,
       logo,
       uiIcon,
-      uiSelect,
       languageSwitcher,
       coreModal,
-      uiCheckbox,
+      kCheckbox,
     },
     data: () => ({
       name: '',

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -40,10 +40,9 @@
       <k-textbox
         ref="username"
         id="username"
-        type="text"
-        autocomplete="username"
-        :label="$tr('username')"
-        :maxlength="30"
+        type="tel"
+        autocomplete="tel"
+        :label="$tr('phoneNumberLabel')"
         :invalid="usernameIsInvalid"
         :invalidText="usernameIsInvalidText"
         @blur="usernameBlurred = true"
@@ -118,13 +117,13 @@
     $trs: {
       createAccount: 'Create an account',
       name: 'Full name',
-      username: 'Username',
+      phoneNumberLabel: 'Phone Number',
       password: 'Password',
       reEnterPassword: 'Re-enter password',
       passwordMatchError: 'Passwords do not match',
       genericError: 'Something went wrong during sign up!',
-      usernameAlphaNumError: 'Username can only contain letters, numbers, and underscores',
-      usernameAlreadyExistsError: 'An account with that username already exists',
+      phoneNumberInvalid: 'Please enter a valid phone number',
+      accountAlreadyExistsError: 'An account with that phone number already exists',
       logIn: 'Sign in',
       appBarHeader: 'Instant Schools',
       finish: 'Finish',
@@ -193,11 +192,11 @@
           if (this.username === '') {
             return this.$tr('required');
           }
-          if (!validateUsername(this.username)) {
-            return this.$tr('usernameAlphaNumError');
+          if (!this.validatePhoneNumber(this.username)) {
+            return this.$tr('phoneNumberInvalid');
           }
           if (!this.usernameDoesNotExistYet) {
-            return this.$tr('usernameAlreadyExistsError');
+            return this.$tr('accountAlreadyExistsError');
           }
         }
         return '';
@@ -291,6 +290,10 @@
         } else if (this.confirmedPasswordIsInvalid) {
           this.$refs.confirmedPassword.focus();
         }
+      },
+      validatePhoneNumber() {
+        const strippedPhoneNumber = this.username.replace(/\D/g, '');
+        return strippedPhoneNumber.length > 8;
       },
     },
     vuex: {

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -382,6 +382,16 @@
       margin-bottom: $form-item-spacing // margin defined for k-textbox
       margin-top: $k-textbox-text-distance
       &-view-prompt
+
+        // duplicating styles from `<a>` in core theme
+        color: $core-action-normal
+        transition: color $core-time ease-out
+        &:hover
+          color: $core-action-dark
+        &:hover:focus, &:focus
+          outline: $core-outline
+        // end dupe 
+
         display: block
         margin-bottom: $form-item-spacing
         padding: 0

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -374,11 +374,13 @@
     &-agreement
       $height-of-prompt = 18px + 16px
       $height-of-checkbox = 48px + 16px
+      $k-textbox-text-distance = 24px // distance from top of text to its label container
       $height-of-error = 16px
 
       display: inline-block
       height: $height-of-prompt + $height-of-checkbox + $height-of-error
       margin-bottom: $form-item-spacing // margin defined for k-textbox
+      margin-top: $k-textbox-text-distance
       &-view-prompt
         display: block
         margin-bottom: $form-item-spacing

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -7,7 +7,7 @@
         <ui-icon class="app-bar-icon"><logo/></ui-icon>
       </template>
       <template slot="brand">
-        {{ $tr('kolibri') }}
+        {{ $tr('appBarHeader') }}
       </template>
       <div slot="actions">
         <router-link id="signin" :to="signInPage">
@@ -126,7 +126,7 @@
       usernameAlphaNumError: 'Username can only contain letters, numbers, and underscores',
       usernameAlreadyExistsError: 'An account with that username already exists',
       logIn: 'Sign in',
-      kolibri: 'Kolibri',
+      appBarHeader: 'Instant Schools',
       finish: 'Finish',
       facility: 'Facility',
       selectFacility: 'Select a facility',

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -133,7 +133,6 @@
   import kButton from 'kolibri.coreVue.components.kButton';
   import uiCheckbox from 'keen-ui/src/UiCheckbox';
   import coreModal from 'kolibri.coreVue.components.coreModal';
-  import uiAlert from 'keen-ui/src/UiAlert';
   import kTextbox from 'kolibri.coreVue.components.kTextbox';
   import uiToolbar from 'keen-ui/src/UiToolbar';
   import logo from 'kolibri.coreVue.components.logo';
@@ -164,7 +163,6 @@
     },
     components: {
       kButton,
-      uiAlert,
       kTextbox,
       uiToolbar,
       logo,

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -74,18 +74,6 @@
         v-model="confirmedPassword"
       />
 
-      <ui-select
-        :name="$tr('selectFacility')"
-        :placeholder="$tr('selectFacility')"
-        :label="$tr('facility')"
-        :value="selectedFacility"
-        :options="facilityList"
-        :invalid="facilityIsInvalid"
-        :error="facilityIsInvalidText"
-        @blur="facilityBlurred = true"
-        @input="updateSelection"
-      />
-
       <!-- ToS modal only shows up if the box empty prior to clicking -->
       <!-- Using UI Checkbox for blur events and v-model -->
       <ui-checkbox
@@ -103,7 +91,6 @@
       >
         {{ termsNotAgreedText }}
       </label>
-
 
       <k-button :disabled="busy" :primary="true" :text="$tr('finish')" type="submit" />
 
@@ -157,8 +144,6 @@
       termsOfServiceModalHeader: 'Terms of service & privacy policy',
       appBarHeader: 'Instant Schools',
       finish: 'Finish',
-      facility: 'Facility',
-      selectFacility: 'Select a facility',
       required: 'This field is required',
     },
     components: {
@@ -177,12 +162,10 @@
       username: '',
       password: '',
       confirmedPassword: '',
-      selection: {},
       nameBlurred: false,
       usernameBlurred: false,
       passwordBlurred: false,
       confirmedPasswordBlurred: false,
-      facilityBlurred: false,
       formSubmitted: false,
       showTerms: false,
       termsAgreed: false,
@@ -197,12 +180,6 @@
           label: facility.name,
           id: facility.id,
         }));
-      },
-      selectedFacility() {
-        if (this.facilityList.length === 1) {
-          return this.facilityList[0];
-        }
-        return this.selection;
       },
       nameIsInvalidText() {
         if (this.nameBlurred || this.formSubmitted) {
@@ -272,27 +249,12 @@
       termsNotAgreed() {
         return !!this.termsNotAgreedText;
       },
-      noFacilitySelected() {
-        return !this.selectedFacility.id;
-      },
-      facilityIsInvalidText() {
-        if (this.facilityBlurred || this.formSubmitted) {
-          if (this.noFacilitySelected) {
-            return this.$tr('required');
-          }
-        }
-        return '';
-      },
-      facilityIsInvalid() {
-        return !!this.facilityIsInvalidText;
-      },
       formIsValid() {
         return (
           !this.nameIsInvalid &&
           !this.usernameIsInvalid &&
           !this.passwordIsInvalid &&
           !this.confirmedPasswordIsInvalid &&
-          !this.facilityIsInvalid &&
           !this.termsNotAgreed
         );
       },
@@ -307,15 +269,12 @@
       },
     },
     methods: {
-      updateSelection(selection) {
-        this.selection = selection;
-      },
       signUp() {
         this.formSubmitted = true;
         const canSubmit = this.formIsValid && !this.busy;
         if (canSubmit) {
           this.signUpAction({
-            facility: this.selectedFacility.id,
+            facility: this.facilityList[0],
             full_name: this.name,
             username: this.username,
             password: this.password,

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -74,32 +74,35 @@
         v-model="confirmedPassword"
       />
 
-      <!-- ToS modal only shows up if the box empty prior to clicking -->
-      <!-- Using UI Checkbox for blur events and v-model -->
-      <label class="terms-agreement">
-        <button
-          type="button"
-          class="terms-agreement-view-prompt"
-          @click="showTerms = true"
-        >
-          {{ $tr('viewTermsOfServicePrompt') }}
-        </button>
+      <div class="terms-agreement">
+        <label for="terms-agreement-checkbox">
+          <button
+            type="button"
+            class="terms-agreement-view-prompt"
+            @click="showTerms = true"
+          >
+            {{ $tr('viewTermsOfServicePrompt') }}
+          </button>
+        </label>
 
         <k-checkbox
           :class="['terms-agreement-checkbox', termsNotAgreed ? 'invalid' : '']"
+          id="terms-agreement-checkbox"
           :checked="termsAgreed"
           @change="termsAgreed = $event"
           @blur="termsAgreementCheckboxBlurred = true"
           :label="$tr('termsAgreementLabel')"
         />
 
-        <span
+        <label
           v-if="termsNotAgreed"
+          aria-live="polite"
+          for="terms-agreement-checkbox"
           class="terms-agreement-error-box"
         >
           {{ termsNotAgreedText }}
-        </span>
-      </label>
+        </label>
+      </div>
 
       <k-button :disabled="busy" :primary="true" :text="$tr('finish')" type="submit" />
 

--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -76,7 +76,7 @@
 
       <!-- ToS modal only shows up if the box empty prior to clicking -->
       <!-- Using UI Checkbox for blur events and v-model -->
-      <label for="terms-agreement-checkbox">
+      <label class="terms-agreement">
         <button
           type="button"
           class="terms-agreement-view-prompt"
@@ -86,7 +86,6 @@
         </button>
 
         <k-checkbox
-          id="terms-agreement-checkbox"
           :class="['terms-agreement-checkbox', termsNotAgreed ? 'invalid' : '']"
           :checked="termsAgreed"
           @change="termsAgreed = $event"
@@ -335,6 +334,7 @@
   $logo-size = (1.64 * 1.125)rem
   $logo-margin = (0.38 * $logo-size)rem
   $keen-invalid-md-red = #f44336
+  $form-item-spacing = 16px // defined in k-textbox
 
   // component, highest level
   #signup-page
@@ -368,10 +368,21 @@
     height: 80vh
     width: 80vw
     &-agreement
+      $height-of-prompt = 18px + 16px
+      $height-of-checkbox = 48px + 16px
+      $height-of-error = 16px
+
+      display: inline-block
+      height: $height-of-prompt + $height-of-checkbox + $height-of-error
+      margin-bottom: $form-item-spacing // margin defined for k-textbox
       &-view-prompt
         display: block
+        margin-bottom: $form-item-spacing
+        padding: 0
         text-decoration: underline
       &-checkbox
+        margin-top: 0
+        margin-bottom: $form-item-spacing
         &.invalid
           color: $keen-invalid-md-red
       &-error-box


### PR DESCRIPTION
Porting over old vf features to new one. part of #53 resolves #79

Totally blanked and added styles - @indirectlylit this going to be a big problem?

Using `ui-checkbox` instead of `k-checkbox` for `v-model` and `blur` events. Didn't think it was worth tweaking `k-checkbox` right now. thoughts?

Also added validation to textbox - see below.

![screenshot from 2017-10-20 18-36-21](https://user-images.githubusercontent.com/9877852/31846814-9dd53480-b5c5-11e7-9502-798e9919d84a.png)
