### PR TITLE
Secondary Raised Button display issues

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/styles/theme.styl
+++ b/kolibri_instant_schools_plugin/assets/src/styles/theme.styl
@@ -9,7 +9,6 @@ $core-action-light = #f44336 // lighter shade of vf-red, found while porting
 $core-action-dark = #690700 // darker shade, suggested by devon
 $core-accent-color = #E11300 // being used in nav
 $core-text-annotation = #686868 // custom vf color
-$core-grey-200 = #333333 // being used for flat button backgrounds
 
 // vf additions
 
@@ -46,5 +45,6 @@ $core-status-wrong = #DF4D4F
 
 $core-grey = #E0E0E0
 
+$core-grey-200 = #EEEEEE
 $core-grey-300 = #E0E0E0
 


### PR DESCRIPTION
After attempting a merge between styling and develop, i saw that secondary-raised-buttons have a global issue, due to the background color being dark in vf's mocks.

k-button's styles defines the text color as $core-default, so if I redefine that in our theme, all of the text in the app will change to that color (which in this case is light, so contrast would become an issue).

I'm thinking we could either:
a) Modify k-button and give it another variable to define the text color, then redefine that
b) Have buttons use a light background

Thoughts?

@jtamiace specifically on option b ^? 