### PR TITLE
Update profile signin

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/state/actions.js
+++ b/kolibri_instant_schools_plugin/assets/src/state/actions.js
@@ -128,6 +128,7 @@ function showSignIn(store) {
   store.dispatch('SET_PAGE_STATE', {});
   store.dispatch('CORE_SET_PAGE_LOADING', false);
   store.dispatch('CORE_SET_ERROR', null);
+  store.dispatch('CORE_SET_LOGIN_ERROR', '');
   store.dispatch('CORE_SET_TITLE', translator.$tr('userSignInPageTitle'));
 }
 

--- a/kolibri_instant_schools_plugin/assets/src/views/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/index.vue
@@ -68,6 +68,9 @@
         if (this.pageName === PageNames.SIGN_UP) {
           return false;
         }
+        if (this.pageName === PageNames.SELECT_PROFILE) {
+          return false;
+        }
         return true;
       },
     },

--- a/kolibri_instant_schools_plugin/assets/src/views/select-profile-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/select-profile-page/index.vue
@@ -115,7 +115,7 @@
     },
     $trs: {
       newProfileButton: 'New profile',
-      selectProfilePageHeader: 'Who is learning today?',
+      selectProfilePageHeader: 'Select profile',
     },
   };
 

--- a/kolibri_instant_schools_plugin/assets/src/views/select-profile-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/select-profile-page/index.vue
@@ -1,33 +1,55 @@
 <template>
 
   <div>
-    <h1>{{ $tr('selectProfilePageHeader') }}</h1>
+    <ui-toolbar
+      type="colored"
+      textColor="white"
+    >
+      <template slot="icon">
+        <ui-icon-button
+          icon="arrow_back"
+          type="secondary"
+          color="white"
+          @click="showSignIn"
+        />
+      </template>
+      <div>
+        <ui-icon class="app-bar-icon">
+          <logo />
+        </ui-icon>
+        <span class="brand">{{ $tr('instantSchoolsBrand') }}</span>
+      </div>
+    </ui-toolbar>
 
-    <div class="profiles">
-      <profiles-list
-        :profiles="profiles"
-        @selectprofile="signInWithProfile"
+    <div class="container">
+      <h1>{{ $tr('selectProfilePageHeader') }}</h1>
+
+      <div class="profiles">
+        <profiles-list
+          :profiles="profiles"
+          @selectprofile="signInWithProfile"
+          :disabled="disableForms"
+        />
+      </div>
+
+      <div class="buttons">
+        <k-button
+          :text="$tr('newProfileButton')"
+          :ariaLabel="$tr('newProfileButton')"
+          :primary="true"
+          @click="openModal"
+          :disabled="disableForms"
+        />
+      </div>
+
+      <new-profile-modal
+        v-if="showNewProfileModal"
+        @submit="addProfileToAccount"
+        @close="closeModal"
         :disabled="disableForms"
+        :showError="newProfileFailed"
       />
     </div>
-
-    <div class="buttons">
-      <k-button
-        :text="$tr('newProfileButton')"
-        :ariaLabel="$tr('newProfileButton')"
-        :primary="true"
-        @click="openModal"
-        :disabled="disableForms"
-      />
-    </div>
-
-    <new-profile-modal
-      v-if="showNewProfileModal"
-      @submit="addProfileToAccount"
-      @close="closeModal"
-      :disabled="disableForms"
-      :showError="newProfileFailed"
-    />
   </div>
 
 </template>
@@ -40,13 +62,22 @@
   import newProfileModal from './new-profile-modal';
   import profilesList from './profiles-list';
   import { createProfile } from '../../state/profileActions';
+  import { showSignIn } from '../../state/actions';
+  import UiToolbar from 'keen-ui/src/UiToolbar';
+  import UiIcon from 'keen-ui/src/UiIcon';
+  import UiIconButton from 'keen-ui/src/UiIconButton';
+  import logo from 'kolibri.coreVue.components.logo';
 
   export default {
     name: 'selectProfilePage',
     components: {
       kButton,
+      logo,
       newProfileModal,
       profilesList,
+      UiToolbar,
+      UiIcon,
+      UiIconButton,
     },
     data() {
       return {
@@ -111,9 +142,12 @@
       actions: {
         createProfile,
         kolibriLogin,
+        showSignIn,
       },
     },
     $trs: {
+      instantSchoolsBrand: 'Instant Schools',
+      logIn: 'Sign in',
       newProfileButton: 'New profile',
       selectProfilePageHeader: 'Select profile',
     },
@@ -124,10 +158,38 @@
 
 <style lang="stylus" scoped>
 
+  $iphone-5-width = 320px
+  $vertical-page-margin = 50px
+
+  .ui-icon
+    background-color: transparent
+    color: white
+
+  #logo
+    // 1.63 * font height
+    height: $logo-size
+    display: inline-block
+    margin-left: $logo-margin
+
+  .app-bar-icon
+    font-size: 40px
+    margin-left: 4px
+    margin-right: 8px
+
+  .brand
+    color: white
+
+  // adapted from sign-up-page .signup-form
+  .container
+    margin-top: $vertical-page-margin
+    margin-left: auto
+    margin-right: auto
+    width: ($iphone-5-width - 10)px
+
   .buttons button
     margin-left: 0
 
   .profiles
-    margin: 1em 0
+    margin: 16px 0
 
 </style>

--- a/kolibri_instant_schools_plugin/assets/src/views/select-profile-page/new-profile-modal.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/select-profile-page/new-profile-modal.vue
@@ -16,13 +16,13 @@
       <form @submit.prevent="submit">
         <k-textbox
           :autofocus="true"
-          :label="$tr('fullName')"
-          v-model="fullName"
-          :invalid="!fullNameIsValid"
-          :invalidText="fullNameInvalidText"
+          :label="$tr('profileName')"
+          v-model="profileName"
+          :invalid="!profileNameIsValid"
+          :invalidText="profileNameInvalidText"
           :maxlength="120"
           :disabled="disabled"
-          @blur="fullNameIsBlurred=true"
+          @blur="profileNameIsBlurred=true"
         />
 
         <div class="buttons">
@@ -64,8 +64,8 @@
     data() {
       return {
         formIsSubmitted: false,
-        fullName: '',
-        fullNameIsBlurred: false,
+        profileName: '',
+        profileNameIsBlurred: false,
       };
     },
     props: {
@@ -79,17 +79,17 @@
       },
     },
     computed: {
-      fullNameShouldValidate() {
-        return this.fullName !== '' || this.fullNameIsBlurred || this.formIsSubmitted;
+      profileNameShouldValidate() {
+        return this.profileName !== '' || this.profileNameIsBlurred || this.formIsSubmitted;
       },
-      fullNameIsValid() {
-        if (this.fullNameShouldValidate) {
-          return this.fullName !== '' && !this.profileAlreadyExists(this.fullName);
+      profileNameIsValid() {
+        if (this.profileNameShouldValidate) {
+          return this.profileName !== '' && !this.profileAlreadyExists(this.profileName);
         }
         return true;
       },
-      fullNameInvalidText() {
-        if (this.profileAlreadyExists(this.fullName)) {
+      profileNameInvalidText() {
+        if (this.profileAlreadyExists(this.profileName)) {
           return this.$tr('profileAlreadyExists');
         }
         return this.$tr('required');
@@ -98,8 +98,8 @@
     methods: {
       submit() {
         this.formIsSubmitted = true;
-        if (this.fullNameIsValid) {
-          return this.$emit('submit', this.fullName);
+        if (this.profileNameIsValid) {
+          return this.$emit('submit', this.profileName);
         }
       },
       closeModal() {
@@ -112,15 +112,15 @@
     vuex: {
       getters: {
         profileAlreadyExists(state) {
-          return function findMatch(fullName) {
-            return Boolean(state.pageState.profiles.find(profile => profile.full_name === fullName));
+          return function findMatch(profileName) {
+            return Boolean(state.pageState.profiles.find(profile => profile.full_name === profileName));
           };
         },
       },
     },
     $trs: {
       cancel: 'Cancel',
-      fullName: 'Full name',
+      profileName: 'Profile name',
       newProfileModalTitle: 'New profile',
       problemCreatingProfile: 'There was a problem creating this profile',
       profileAlreadyExists: 'This profile already exists',


### PR DESCRIPTION
For #99 

1. Changes the copy around "who's learning", and "full name"
1. Switches the app-bar with the ui-toolbar with a back button and branding
1. Modifies `showSignIn` action to erase login errors in case first attempt at login fails (doesn't show error when going back).

![profileappbar](https://user-images.githubusercontent.com/10248067/32572361-29d586c0-c47f-11e7-8420-3a5f4143d32e.gif)
