### PR TITLE
Bringing back form styles in sign up page

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/sign-up-page/index.vue
@@ -335,12 +335,20 @@
   $logo-size = 36px
   $logo-margin = 16px
   $keen-invalid-md-red = #f44336
+  $form-item-spacing = 16px // defined in k-textbox
 
   // component, highest level
   #signup-page
     width: 100%
     height: 100%
     overflow-y: auto
+
+  // Action Bar
+  #logo
+    // 1.63 * font height
+    height: $logo-size
+    display: inline-block
+    margin-left: $logo-margin
 
   #signin
     margin-right: 1em
@@ -356,6 +364,45 @@
     margin-left: auto
     margin-right: auto
     width: ($iphone-5-width - 20)px
+
+  .terms
+    height: 80vh
+    width: 80vw
+    border: none
+    &-agreement
+      $height-of-prompt = 18px + 16px
+      $height-of-checkbox = 48px + 16px
+      $k-textbox-text-distance = 24px // distance from top of text to its label container
+      $height-of-error = 16px
+
+      display: inline-block
+      height: $height-of-prompt + $height-of-checkbox + $height-of-error
+      margin-bottom: $form-item-spacing // margin defined for k-textbox
+      margin-top: $k-textbox-text-distance
+      &-view-prompt
+
+        // duplicating styles from `<a>` in core theme
+        color: $core-action-normal
+        transition: color $core-time ease-out
+        &:hover
+          color: $core-action-dark
+        &:hover:focus, &:focus
+          outline: $core-outline
+        // end dupe 
+
+        display: block
+        margin-bottom: $form-item-spacing
+        padding: 0
+        text-decoration: underline
+      &-checkbox
+        margin-top: 0
+        margin-bottom: $form-item-spacing
+        &.invalid
+          color: $keen-invalid-md-red
+      &-error-box
+        display: block
+        color: $keen-invalid-md-red // same color as input error messages
+        font-size: 14px // same as error messages from inputs
 
   .app-bar-icon
     display: inline-block


### PR DESCRIPTION
This merge: https://github.com/fle-internal/kolibri-instant-schools-plugin/commit/503e486f4ecfee936032fe1544fc8ec0553087c8

Wiped out some styling that needed to be there without a merge conflict. Bringing them back 

# Without Styles:
Fresh:
![image](https://user-images.githubusercontent.com/9877852/32760756-9ac76244-c8a4-11e7-8176-45a810b3c83b.png)
Errors:
![image](https://user-images.githubusercontent.com/9877852/32760766-a6509e1e-c8a4-11e7-9e01-334911cf1d26.png)


# With Styles
Fresh:
![image](https://user-images.githubusercontent.com/9877852/32760733-80181574-c8a4-11e7-88de-d3425fbe809d.png)

Errors:
![image](https://user-images.githubusercontent.com/9877852/32760729-787662a8-c8a4-11e7-80b7-ef3fdd85ca5a.png)


