### PR TITLE
Send guests straight to the about page.

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/views/SignInPage/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/SignInPage/index.vue
@@ -144,7 +144,7 @@
             >
               <KExternalLink
                 :text="$tr('accessAsGuest')"
-                :href="guestURL"
+                :href="aboutUrl"
                 :primary="false"
                 appearance="flat-button"
               />
@@ -350,8 +350,8 @@
       logoText() {
         return this.$theme.signIn.title ? this.$theme.signIn.title : this.$tr('kolibri');
       },
-      guestURL() {
-        return urls['kolibri:core:guest']();
+      aboutUrl() {
+        return urls['kolibri:about:about']();
       },
       backgroundImageStyle() {
         if (this.$theme.signIn.background) {


### PR DESCRIPTION
The "View as guest" link on the signup page now sends the user straight to the about page where they can then move on to the Learn section.

Guest will see this every time they access as a guest.

Addressing: https://github.com/learningequality/kolibri/issues/6210 without having to touch Kolibri.