### PR TITLE
Set cookie to avoid about on every guest login

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/views/SignInPage/index.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/SignInPage/index.vue
@@ -144,7 +144,8 @@
             >
               <KExternalLink
                 :text="$tr('accessAsGuest')"
-                :href="aboutUrl"
+                :href="guestUrl"
+                @click.native="checkGuestUrl"
                 :primary="false"
                 appearance="flat-button"
               />
@@ -269,6 +270,7 @@
         privacyModalVisible: false,
         whatsThisModalVisible: false,
         showPwResetModal: false,
+        guestUrl: urls['kolibri:about:about'](),
       };
     },
     computed: {
@@ -406,6 +408,16 @@
     },
     methods: {
       ...mapActions('signIn', ['showSelectProfilePage']),
+      checkGuestUrl() {
+        if(document.cookie.includes('accessed_as_guest')) {
+          this.guestUrl = urls['kolibri:learn:learn']();
+        } else {
+          var date = new Date();
+          date.setTime(date.getTime() + (365*24*60*60*1000));
+          var expires = "; expires=" + date.toUTCString();
+          document.cookie = "accessed_as_guest=true; path=/" + expires;
+        }
+      },
       closeFacilityModal() {
         this.facilityModalVisible = false;
         this.$nextTick().then(() => {


### PR DESCRIPTION
This sets a cookie to see if the site was accessed as a guest at some point to avoid showing the About page every time someone accesses as a guest.

Originally, https://github.com/learningequality/kolibri-instant-schools-plugin/pull/166 fixed the issue where people were _always_ going to the Learn section, but it made everybody go to the About page every time.

Now we go Learn when we've already seen the About page as a guest.