### PR TITLE
Reset password host

### DIFF
--- a/kolibri_instant_schools_plugin/auth/api.py
+++ b/kolibri_instant_schools_plugin/auth/api.py
@@ -65,7 +65,7 @@ class PasswordResetTokenViewset(viewsets.ViewSet):
         token = PasswordResetToken.generate_new_token(phone=phone)
 
         # determine base URL from the scheme/host in this request, so we send people back to a server they can access
-        baseurl = "{scheme}://{host}".format(scheme=request.scheme, host=request.META['HTTP_X_FORWARDED_FOR'])
+        baseurl = "{scheme}://{host}".format(scheme=request.scheme, host=request.get_host())
 
         # send the password reset URL to the phone number via SMS
         try:

--- a/kolibri_instant_schools_plugin/auth/api.py
+++ b/kolibri_instant_schools_plugin/auth/api.py
@@ -65,7 +65,7 @@ class PasswordResetTokenViewset(viewsets.ViewSet):
         token = PasswordResetToken.generate_new_token(phone=phone)
 
         # determine base URL from the scheme/host in this request, so we send people back to a server they can access
-        baseurl = "{scheme}://{host}".format(scheme=request.scheme, host=request.META['HTTP_HOST'])
+        baseurl = "{scheme}://{host}".format(scheme=request.scheme, host=request.META['HTTP_X_FORWARDED_FOR'])
 
         # send the password reset URL to the phone number via SMS
         try:

--- a/kolibri_instant_schools_plugin/instant_schools_settings.py
+++ b/kolibri_instant_schools_plugin/instant_schools_settings.py
@@ -27,3 +27,6 @@ LANGUAGES = [
     ('fr-fr', 'Français'),
     ('pt-br', 'Português'),
 ]
+
+USE_X_FORWARDED_HOST = True
+USE_X_FORWARDED_PORT = True


### PR DESCRIPTION
When generating the reset password link, we previously wouldn't account for the X-Forwarded-* headers, so the link would be generated improperly.

Changes:

In the plugin settings file, add the `USE_X_FORWARDED_HOST|PORT` settings and set to `True`

This also involves setting nginx settings that forward the settings in the nginx config:

```
proxy_set_header X-Forwarded-Host $host:$server_port;
proxy_set_header X-Forwarded-Server $host;
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
```