### PR TITLE
remove reference to unused buildConfig entry, fix buttons on reset form

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/views/SignInPage/ResetPasswordModal/PhoneNumberForm.vue
+++ b/kolibri_instant_schools_plugin/assets/src/views/SignInPage/ResetPasswordModal/PhoneNumberForm.vue
@@ -24,7 +24,7 @@
         :invalidText="$tr('required')"
         :disabled="disabled"
       />
-      <div class="buttons">
+      <KButtonGroup style="float: right">
         <KButton
           :text="$tr('cancel')"
           :primary="false"
@@ -37,7 +37,7 @@
           :primary="true"
           :disabled="disabled"
         />
-      </div>
+      </KButtonGroup>
     </form>
   </div>
 
@@ -121,15 +121,6 @@
   .instructions {
     margin: 1em 0;
     text-align: left;
-  }
-
-  .buttons {
-    margin-top: 1em;
-    text-align: right;
-  }
-
-  button[type='submit'] {
-    margin-right: 0;
   }
 
 </style>

--- a/kolibri_instant_schools_plugin/buildConfig.js
+++ b/kolibri_instant_schools_plugin/buildConfig.js
@@ -12,12 +12,6 @@ module.exports = [
     },
   },
   {
-    bundle_id: 'instant_schools_profile_nav_action',
-    webpack_config: {
-      entry: './assets/src/views/SideNav/UserProfileSideNavEntry.vue',
-    },
-  },
-  {
     bundle_id: 'instant_schools_about_nav_action',
     webpack_config: {
       entry: './assets/src/views/SideNav/AboutSideNavEntry.vue',


### PR DESCRIPTION
Remove reference no longer needed in buildConfig since it was deleted previously.

Fix spacing on button group in the password reset form. Fixing Kolibri#9202