### PR TITLE
don't GET profiles list, POST for it to avoid plaintext passwords

### DIFF
--- a/kolibri_instant_schools_plugin/assets/src/modules/signIn/actions.js
+++ b/kolibri_instant_schools_plugin/assets/src/modules/signIn/actions.js
@@ -6,9 +6,9 @@ export function showSelectProfilePage(store, params) {
   const { phone, password, facility } = params;
   return client({
     url: `${urls[
-      'kolibri:kolibri_instant_schools_plugin:phoneaccountprofile_list'
-    ]()}?password=${password}&phone=${phone}`,
-    method: 'GET',
+      'kolibri:kolibri_instant_schools_plugin:phoneaccountprofile-profiles'
+    ]()}`,
+    method: 'POST',
     data: {
       password,
       phone,

--- a/kolibri_instant_schools_plugin/auth/api.py
+++ b/kolibri_instant_schools_plugin/auth/api.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils.translation import ugettext as _
 from rest_framework import filters, permissions, status, viewsets, serializers
 from rest_framework.response import Response
+from rest_framework.decorators import action
 from kolibri.core.auth.models import Facility, FacilityUser
 from kolibri.core.auth.api import SignUpViewSet, FacilityUserViewSet
 from kolibri.core.auth.serializers import FacilityUserSerializer
@@ -153,7 +154,7 @@ class PasswordChangeViewset(viewsets.ViewSet):
             resettoken.use_token()
 
             # change the password for all accounts associated with this phone number
-            set_password_for_phone(phone, password)
+            set_password_for_hashed_phone(hash_phone(phone), password)
 
         # return a 200 to indicate having successfully changed the passwords
         return Response("", status=status.HTTP_200_OK)
@@ -197,20 +198,21 @@ class PhoneAccountProfileViewset(viewsets.ViewSet):
 
         return Response(username, status=status.HTTP_201_CREATED)
 
-    def list(self, request):
+    @action(methods=["POST"], detail=False)
+    def profiles(self, request):
         """
         Get a list of profiles associated with a phone number (authenticated by password).
 
         Usage:
 
-            GET /user/api/phoneaccountprofile/?phone=<phone>&password=<password>
+            POST {"phone": "<phone>", "password": "<password>"} to /user/api/phoneaccountprofile/
                 If successful, returns status 200 with a list of dicts with `full_name` and `username`.
                 If no accounts are found, returns status 404.
                 If password fails, returns status 401.
         """
         # extract the phone and password from the query params
-        phone = normalize_phone_number(request.query_params.get('phone', ''))
-        password = request.query_params.get('password', '')
+        phone = normalize_phone_number(request.data['phone'])
+        password = request.data['password']
 
         # get all user profiles associated with the phone number
         users = FacilityUser.objects.filter(username__in=get_usernames(hash_phone(phone)))

--- a/kolibri_instant_schools_plugin/auth/api.py
+++ b/kolibri_instant_schools_plugin/auth/api.py
@@ -211,8 +211,8 @@ class PhoneAccountProfileViewset(viewsets.ViewSet):
                 If password fails, returns status 401.
         """
         # extract the phone and password from the query params
-        phone = normalize_phone_number(request.data['phone'])
-        password = request.data['password']
+        phone = normalize_phone_number(request.data.get('phone', ''))
+        password = request.data.get('password', '')
 
         # get all user profiles associated with the phone number
         users = FacilityUser.objects.filter(username__in=get_usernames(hash_phone(phone)))


### PR DESCRIPTION
NCC Group found that we were passing the user's password as plaintext to the endpoint that listed all profiles for the given phone number.

This PR changes the `list` endpoint of the `PhoneAccountProfileViewset` to wrap with the `@action` decorator that expects a POST and updates the code to use POST data rather than the query string.